### PR TITLE
Add support for custom errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function createError (product, data, params) {
   var error
 
   // Is this a custom error?
-  if (typeof data !== 'string') {
+  if (typeof data !== 'string' && typeof data !== 'number') {
     error = Object.assign({}, data)
 
     error.code = data.code || product.toUpperCase() + '-CUSTOM'

--- a/index.js
+++ b/index.js
@@ -13,18 +13,28 @@ module.exports.createWebError = function (code, params) {
   return createError('web', code, params)
 }
 
-function createError (product, code, params) {
-  var error = codes[product.toLowerCase()][code]
+function createError (product, data, params) {
+  var error
 
-  if (!error) {
-    error = {
-      code: `${product.toUpperCase()}-${code}`
-    }
+  // Is this a custom error?
+  if (typeof data !== 'string') {
+    error = Object.assign({}, data)
+
+    error.code = data.code || product.toUpperCase() + '-CUSTOM'
   } else {
-    delete error.params
-    error.details = template(error.details, params)
+    error = codes[product.toLowerCase()][data]
+
+    if (!error) {
+      error = {
+        code: `${product.toUpperCase()}-${data}`
+      }
+    } else {
+      delete error.params
+      error.details = template(error.details, params)
+    }
+
+    error.docLink = 'http://docs.dadi.tech/errors/' + product + '/' + product.toUpperCase() + '-' + data
   }
 
-  error.docLink = 'http://docs.dadi.tech/errors/' + product + '/' + product.toUpperCase() + '-' + code
   return error
 }

--- a/test/test.js
+++ b/test/test.js
@@ -65,6 +65,33 @@ describe('Error Formatting', function (done) {
     })
   })
 
+  describe('Custom Errors', function () {
+    it('should return a custom error object is the input is not a string', function (done) {
+      var errorObject = {
+        code: 'PUBLISH-AUTH',
+        message: 'The authentication failed',
+        remainingAttempts: 3
+      }
+      var err = formatError.createApiError(errorObject)
+
+      JSON.stringify(err).should.eql(JSON.stringify(errorObject))
+
+      done()
+    })
+
+    it('should attach a default code to a custom error if one is not provided', function (done) {
+      var errorObject = {
+        message: 'Something has failed'
+      }
+      var err = formatError.createApiError(errorObject)
+
+      err.message.should.eql(errorObject.message)
+      err.code.should.eql('API-CUSTOM')
+
+      done()
+    })
+  })
+
   describe('Unknown Errors', function () {
     it('should return the code in place of an error', function (done) {
       var err = formatError.createApiError('1001', { field: 'author' })


### PR DESCRIPTION
This PR adds support for delivering custom error objects. It's a requirement for #2, https://github.com/dadi/api/issues/273 and makes https://github.com/dadi/api/issues/289 easier.

If the format functions receive a string or a number as a first argument, everything will work the same: the error code will be looked up in the JSON files and the error will be formated. Otherwise, the input will be used to form a custom error object, attaching a custom code (e.g. `API-CUSTOM`) if one hasn't been specified.